### PR TITLE
Add GitHub Action for Jira ticket description

### DIFF
--- a/.github/workflows/jira-pr-validation.yml
+++ b/.github/workflows/jira-pr-validation.yml
@@ -1,0 +1,55 @@
+name: jira
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  jira-validation-and-linking:
+    runs-on: ubuntu-latest
+    env:
+      JIRA_BASE_URL: https://issues.redhat.com
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find Jira issue keys in commits
+        id: find-issues
+        uses: atlassian/gajira-find-issue-key@master
+        with:
+          from: commits
+
+      - name: Validate Jira issues exist and are accessible
+        if: steps.find-issues.outputs.issue
+        uses: atlassian/gajira-transition@master
+        with:
+          issue: ${{ steps.find-issues.outputs.issue }}
+          transition: "none"
+        continue-on-error: false
+        env:
+          JIRA_API_TOKEN: ${{ secrets.JIRA_TOKEN }}
+
+      - name: Add Jira description to PR (smart duplicate avoidance)
+        if: steps.find-issues.outputs.issue
+        uses: cakeinpanic/jira-description-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          jira-token: ${{ secrets.JIRA_TOKEN }}
+          jira-base-url: ${{ env.JIRA_BASE_URL }}
+          custom-issue-number-regexp: 'ECOPROJECT-\d+'
+          fail-when-jira-issue-not-found: true
+
+      - name: Add PR link to Jira issue
+        if: steps.find-issues.outputs.issue
+        uses: atlassian/gajira-comment@master
+        with:
+          issue: ${{ steps.find-issues.outputs.issue }}
+          comment: |
+            🔗 **GitHub Pull Request**: [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})
+            
+            **Author**: @${{ github.event.pull_request.user.login }}
+            **Status**: ${{ github.event.pull_request.state }}
+            
+            _Automatically linked by GitHub Actions_


### PR DESCRIPTION
This commit introduces a new GitHub Action workflow that automatically adds a Jira ticket description when a pull request is opened or edited. The action utilizes the 'cakeinpanic/jira-description-action' and requires GitHub and Jira tokens for authentication.

Jira-issue-key: ECOPROJECT-3163

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a GitHub Action workflow for validating Jira ticket links and descriptions in pull requests.

### Why are these changes being made?

This change aims to ensure that pull requests include correct and valid Jira ticket references, enhancing traceability and integration between our version control and issue tracking systems. By automating the validation and linking process, we reduce manual errors and streamline our development workflow.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced automated validation and linking of Jira issues to pull requests. When a pull request is opened, related Jira issues are checked and validated, and relevant information is added to both the pull request and the Jira issue for improved traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->